### PR TITLE
Move repos table to rosdistro db

### DIFF
--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -26,6 +26,9 @@ tables:
     github_issues_updates:
         - id
         - last_updated_at
+    repo_updates:
+        - id
+        - last_updated_at
 
 
 special_types:

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1,12 +1,4 @@
 tables:
-    repos:
-        - id
-        - key
-        - server
-        - org
-        - repo
-        - url
-        - status
     github_stats:
         - id
         - forks

--- a/data/rosdistro.yaml
+++ b/data/rosdistro.yaml
@@ -15,8 +15,21 @@ tables:
         - commit_id
         - distro
         - count
+    repos:
+        - id
+        - server
+        - org
+        - repo
+        - url
+        - status
+    remap_repos:
+        - id
+        - new_id
+    tags_checked:
+        - commit_id
 special_types:
     id: int
+    new_id: int
     commit_id: int
     date: int
     change_index: int

--- a/generate_html.py
+++ b/generate_html.py
@@ -231,15 +231,17 @@ for blob in STRUCTURE:
 if args.filter and args.filter != 'repos':
     exit(0)
 
+rosdistro_db = MetricDB('rosdistro')
 repos_db = MetricDB('repos')
+github_repos = repos.get_github_repos(rosdistro_db)
 REPOS_FOLDER = OUTPUT_FOLDER / 'repos'
 REPOS_FOLDER.mkdir(exist_ok=True)
-for repo_dict in tqdm(repos_db.query('SELECT * FROM repos WHERE server="github.com" and status is null')):
+for id, repo_dict in tqdm(github_repos.items()):
     name = '{org}/{repo}'.format(**repo_dict)
     template = j2_env.get_template(subpage.get('template', 'basic_chart.html'))
     filename = '{org}_{repo}.html'.format(**repo_dict)
 
-    repo_page = {'name': name, 'chart': charts.get_repo_issues(repos_db, name, repo_dict['id'])}
+    repo_page = {'name': name, 'chart': charts.get_repo_issues(repos_db, name, id)}
 
     repo_page['level1'] = 'repos.html'
     repo_page['menu'] = menu

--- a/ros_metrics/metric_db.py
+++ b/ros_metrics/metric_db.py
@@ -162,6 +162,14 @@ class MetricDB:
         query = f'UPDATE {table} SET {value_str} ' + clause
         self.execute(query, values)
 
+    def get_next_id(self, table, start_id=0):
+        """ Return an id that is not yet in the table """
+        all_ids = self.lookup_all('id', table)
+        id = start_id
+        while id in all_ids:
+            id += 1
+        return id
+
     # DB Structure Operations
     def get_field_type(self, field):
         """ Returns the type of a given field, based on the db_structure """

--- a/ros_metrics/repo_utils.py
+++ b/ros_metrics/repo_utils.py
@@ -72,6 +72,31 @@ def clone_or_update(url, path=None, update=True):
             repo.remotes.origin.pull()
     return repo, path
 
+
+def resolve(url):
+    if url.startswith('git@'):
+        return url
+    original = url
+    try:
+        while True:
+            r = requests.get(url, allow_redirects=False, timeout=3.0)
+            if r.status_code != 301:
+                break
+            url = r.headers['Location']
+    except requests.exceptions.ConnectTimeout:
+        raise
+    except Exception as e:
+        print(url, e)
+        return None
+
+    if original.endswith('.git') and not url.endswith('.git'):
+        url += '.git'
+    if not original.endswith('/') and url.endswith('/'):
+        url = url[:-1]
+
+    return url
+
+
 def blob_contents(blob):
     if blob is None:
         return ''

--- a/ros_metrics/repo_utils.py
+++ b/ros_metrics/repo_utils.py
@@ -1,0 +1,81 @@
+import git
+import io
+import pathlib
+import re
+import requests
+
+GITHUB_HTTP_PATTERN = re.compile('https?://(?P<server>github\.com)/(?P<org>[^/]+)/(?P<repo>.+?)(?:\.git)?$')
+GITHUB_SSH_PATTERN = re.compile('git@(?P<server>github\.com):(?P<org>[^/]+)/(?P<repo>.+)\.git')
+BB_PATTERN = re.compile('https://(?P<server>bitbucket\.org)/(?P<org>.*)/(?P<repo>.+)')
+GITLAB_HTTP_PATTERN = re.compile('https?://(?P<server>gitlab\.[^/]+)/(?P<org>[^/]+)/(?P<repo>.+).git')
+GITLAB_SSH_PATTERN = re.compile('git@(?P<server>gitlab\.[^/]+):(?P<org>[^/]+)/(?P<repo>.+)\.git')
+GOOGLECODE_PATTERN = re.compile('https?://(?P<org>[^\.]+)\.(?P<server>googlecode.com)/svn/.*/(?P<repo>.+)')
+KFORGE_PATTERN = re.compile('https?://(?P<server>kforge.ros.org)/(?P<org>[^/]+)/(?P<repo>.+)')
+CODEROS_PATTERN = re.compile('https?://(?P<server>code.ros.org)/svn/(?P<org>[^/]+)/stacks/(?P<repo>.+)/trunk')
+SF_PATTERN = re.compile('https?://svn.(?P<server>code.sf.net)/p/(?P<org>[^/]+)/code/trunk/(?:stacks/)?(?P<repo>.+)')
+
+PATTERNS = [GITHUB_HTTP_PATTERN, GITHUB_SSH_PATTERN, BB_PATTERN, GITLAB_HTTP_PATTERN, GITLAB_SSH_PATTERN,
+            GOOGLECODE_PATTERN, KFORGE_PATTERN, CODEROS_PATTERN, SF_PATTERN]
+
+REPOS_CACHE_PATH = pathlib.Path('cache/repos')
+
+
+def match_git_host(url):
+    if not url:
+        return
+    for pattern in PATTERNS:
+        m = pattern.match(url)
+        if m:
+            return dict([(k, v.lower()) for (k, v) in m.groupdict().items()])
+
+
+def get_cache_folder(repo_dict):
+    return REPOS_CACHE_PATH / repo_dict['org'] / repo_dict['repo']
+
+
+class CloneException(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+CLONE_MESSAGES = [
+    ('mercurial', 'Mercurial (hg) is required'),
+    ('no_access', 'HTTP Basic: Access denied'),
+    ('no_access', 'Permission denied'),
+    ('no_access', 'Connection refused'),
+    ('missing', 'not found'),
+]
+
+
+def clone_or_update(url, path=None, update=True):
+    if path is None:
+        repo_dict = match_git_host(url)
+        path = get_cache_folder(repo_dict)
+
+    if not path.exists():
+        try:
+            repo = git.Repo.clone_from(url, path)
+        except git.GitCommandError as e:
+            if not url.startswith('git@'):
+                r = requests.get(url, timeout=3.0)
+                if r.status_code == 404:
+                    raise CloneException('missing')
+
+            for status, msg in CLONE_MESSAGES:
+                if msg in e.stderr:
+                    raise CloneException(status)
+            print(e)
+            exit(0)
+    else:
+        repo = git.Repo(path)
+        if update:
+            repo.remotes.origin.pull()
+    return repo, path
+
+def blob_contents(blob):
+    if blob is None:
+        return ''
+    s = ''
+    with io.BytesIO(blob.data_stream.read()) as f:
+        s += f.read().decode('utf-8')
+    return s

--- a/ros_metrics/repos.py
+++ b/ros_metrics/repos.py
@@ -1,119 +1,47 @@
-from .repo_utils import clone_or_update, get_cache_folder, CloneException, match_git_host
-from .rosdistro import get_rosdistro_repo, REPO_PATH
-from .constants import distros
+from .repo_utils import clone_or_update, get_cache_folder, CloneException, match_git_host, resolve
+from .rosdistro import get_repo_id, get_rosdistro_repos
 from .metric_db import MetricDB
 from .reports import ONE_WEEK
 from .util import get_github_api, now_epoch, epoch_to_datetime, datetime_to_epoch
-import pathlib
 import git
 import github
-import yaml
 import collections
+import requests
 from tqdm import tqdm
 
-FORBIDDEN_KEYS = ['-release', 'ros.org', 'svn', 'code.google.com']
 
-
-def get_raw_distro_dict(update=False):
-    if update:
-        get_rosdistro_repo()
-    rosdistro_path = pathlib.Path(REPO_PATH)
-
-    all_repos = collections.defaultdict(dict)
-
-    for distro in tqdm(distros, 'updating distros'):
-        distro_path = rosdistro_path / distro / 'distribution.yaml'
-        if not distro_path.exists():
-            continue
-        distro_dict = yaml.load(open(str(distro_path)))
-        repos = distro_dict['repositories']
-
-        for name, repo in sorted(repos.items()):
-            url = repo.get('source', repo.get('doc', {})).get('url')
-            if not url:
-                release_url = repo.get('release', {}).get('url')
-                if not release_url:
+def check_urls(rosdistro_db):
+    results = rosdistro_db.query('SELECT id, org, repo, url FROM repos WHERE status is null ORDER BY id')
+    if not results:
+        return
+    for repo_dict in tqdm(results, 'checking repo urls'):
+        try:
+            new_url = resolve(repo_dict['url'])
+            if new_url != repo_dict['url']:
+                repo_dict2 = match_git_host(new_url)
+                if repo_dict2 is None:
                     continue
-                repo_dict = match_git_host(release_url)
-                if not repo_dict:
-                    continue
-
-                folder = get_cache_folder(repo_dict)
-                if not folder.exists():
-                    try:
-                        git.Repo.clone_from(release_url, str(folder))
-                    except Exception as e:
-                        continue
-
-                tracks_file = folder / 'tracks.yaml'
-                if not tracks_file.exists():
-                    continue
-                tracks = yaml.load(open(tracks_file))
-                if distro in tracks['tracks']:
-                    url = tracks['tracks'][distro]['vcs_uri']
-                else:
-                    continue
-            url = url.lower()
-            all_repos[name][distro] = url
-    return all_repos
-
-
-def two_substring_match(urls, subs, return_match=False):
-    if len(urls) != 2:
-        return False
-
-    a, b = urls
-    if subs in a and subs not in b:
-        return a if return_match else b
-    if subs in b and subs not in a:
-        return b if return_match else a
-    return None
-
-
-def get_repo_list(db):
-    all_repos = get_raw_distro_dict()
-    running_count = db.count('repos')
-    for name, repo_dict in all_repos.items():
-        urls = list(set(repo_dict.values()))
-        clean_urls = []
-        if len(urls) == 1:
-            for key in FORBIDDEN_KEYS:
-                if key in urls[0]:
-                    break
+                new_id = get_repo_id(rosdistro_db, repo_dict2)
+                if new_id is None:
+                    new_id = rosdistro_db.get_next_id('repos')
+                    repo_dict2['url'] = new_url
+                    repo_dict2['id'] = new_id
+                    rosdistro_db.insert('repos', repo_dict2)
+                repo_dict['status'] = 'remap'
+                rosdistro_db.insert('remap_repos', {'id': repo_dict['id'], 'new_id': new_id})
             else:
-                clean_urls.append(urls[0])
-        elif two_substring_match(urls, 'ros2'):
-            clean_urls += urls
-        else:
-            for key in FORBIDDEN_KEYS:
-                x = two_substring_match(urls, key)
-                if x:
-                    clean_urls.append(x)
-                    break
-            else:
-                # TODO: 404, 301 resolution
-                pass
-
-        for url in clean_urls:
-            d = match_git_host(url)
-            if not d:
-                # print(url)
-                continue
-            id = db.lookup('id', 'repos', 'WHERE key="{}" and url="{}"'.format(name, url))
-            if id is None:
-                d['key'] = name
-                d['url'] = url
-                d['id'] = running_count
-                running_count += 1
-                db.insert('repos', d)
+                repo_dict['status'] = 'ok'
+        except requests.exceptions.ConnectTimeout:
+            repo_dict['status'] = 'missing'
+        rosdistro_db.update('repos', repo_dict)
 
 
-def clone(db, debug=False):
+def clone(rosdistro_db, repos_db, rosdistro_ids, debug=False):
     repos = {}
     to_clone = []
 
-    for repo_dict in db.query('SELECT id, org, repo, url, status FROM repos ORDER BY id'):
-        if repo_dict['status'] is not None:
+    for repo_dict in rosdistro_db.query('SELECT * FROM repos WHERE status = "ok" ORDER BY id'):
+        if repo_dict['id'] not in rosdistro_ids:
             continue
         folder = get_cache_folder(repo_dict)
         if folder.exists():
@@ -130,18 +58,18 @@ def clone(db, debug=False):
         try:
             repo, path = clone_or_update(repo_dict['url'], folder)
             repos[id] = repo
-            db.update('repo_updates', {'id': id, 'last_updated_at': ts})
+            repos_db.update('repo_updates', {'id': id, 'last_updated_at': ts})
         except CloneException as e:
             repo_dict['status'] = e.message
-            db.update('repos', repo_dict)
+            rosdistro_db.update('repos', repo_dict)
     return repos
 
 
-def update(db, repos, update_period=300000):
+def update(repos_db, repos, update_period=300000):
     ts = now_epoch()
     to_update = []
     for repo_id, repo in repos.items():
-        last_updated_at = db.lookup('last_updated_at', 'repo_updates', f'WHERE id={repo_id}')
+        last_updated_at = repos_db.lookup('last_updated_at', 'repo_updates', f'WHERE id={repo_id}')
         if last_updated_at and ts - last_updated_at < update_period:
             continue
         to_update.append((repo_id, repo))
@@ -152,48 +80,41 @@ def update(db, repos, update_period=300000):
     for repo_id, repo in tqdm(to_update, 'updating repos'):
         try:
             repo.remotes.origin.pull()
-            db.update('repo_updates', {'id': repo_id, 'last_updated_at': ts})
+            repos_db.update('repo_updates', {'id': repo_id, 'last_updated_at': ts})
         except git.GitCommandError as e:
             print(repo, e)
 
 
-def check_statuses(db):
-    for repo_dict in tqdm(db.query('SELECT id, org, repo, url FROM repos WHERE status is null ORDER BY id'),
+def check_statuses(rosdistro_db, rosdistro_ids):
+    for repo_dict in tqdm(rosdistro_db.query('SELECT * FROM repos WHERE status = "ok" ORDER BY id'),
                           desc='checking repo status'):
-        # Check for duplicates
-        url = repo_dict['url']
-        matches = db.lookup_all('id', 'repos', f'WHERE url="{url}" and status is null')
-        if len(matches) > 1 and matches[0] == repo_dict['id']:
-            for match in matches[1:]:
-                repo_dict = db.query(f'SELECT * from REPOS WHERE id={match}')[0]
-                repo_dict['status'] = 'dupe'
-                db.update('repos', repo_dict)
-
+        if repo_dict['id'] not in rosdistro_ids:
+            continue
         # Count packages
         folder = get_cache_folder(repo_dict)
         xml = list(folder.rglob('package.xml')) + list(folder.rglob('manifest.xml'))
         if len(xml) > 0:
             continue
         repo_dict['status'] = 'not_ros'
-        db.update('repos', repo_dict)
+        rosdistro_db.update('repos', repo_dict)
 
 
-def get_github_repos(db):
+def get_github_repos(rosdistro_db, rosdistro_ids=None):
+    if rosdistro_ids is None:
+        rosdistro_ids = get_rosdistro_repos(rosdistro_db)
     repos = {}
-    for repo_dict in db.query('SELECT id, org, repo, status FROM repos WHERE server="github.com"'):
-        if repo_dict['status'] is not None:
+    for repo_dict in rosdistro_db.query('SELECT id, org, repo FROM repos WHERE status="ok" and server="github.com"'):
+        if repo_dict['id'] not in rosdistro_ids:
             continue
-        del repo_dict['status']
         repos[repo_dict['id']] = repo_dict
     return repos
 
 
-def get_github_stats(db, limit=3000000):  # ~1 month
-    existing_stats = db.dict_lookup('id', 'last_updated_at', 'github_stats')
-    repos = get_github_repos(db)
+def get_github_stats(repos_db, github_repos, limit=3000000):  # ~1 month
+    existing_stats = repos_db.dict_lookup('id', 'last_updated_at', 'github_stats')
     now = now_epoch()
     to_crawl = []
-    for repo_id, repo_dict in repos.items():
+    for repo_id, repo_dict in github_repos.items():
         if repo_id not in existing_stats:
             to_crawl.append(repo_dict)
         elif now - existing_stats[repo_id] > limit:
@@ -207,28 +128,18 @@ def get_github_stats(db, limit=3000000):  # ~1 month
         try:
             repo = gh.get_repo('{org}/{repo}'.format(**repo_dict))
         except github.GithubException as e:
-            if e.status == 404:
-                repo_dict['status'] = 'missing'
-                db.update('repos', repo_dict)
-                continue
-            else:
-                raise e
-
-        if repo.stargazers_count != repo.watchers_count:
-            print(repo)
-            print(repo.watchers_count)
-            print(repo.stargazers_count)
-            break
+            # This case should be handled by check_urls
+            continue
 
         row = {'id': repo_dict['id'],
                'forks': repo.network_count,
                'stars': repo.stargazers_count,
                'subs': repo.subscribers_count}
         row['last_updated_at'] = now
-        db.update('github_stats', row)
+        repos_db.update('github_stats', row)
 
 
-def get_github_repo_issues(db, gh, repo_dict, last_updated_at):
+def get_github_repo_issues(repos_db, gh, repo_dict, last_updated_at):
     try:
         repo_str = '{org}/{repo}'.format(**repo_dict)
         repo = gh.get_repo(repo_str)
@@ -279,20 +190,19 @@ def get_github_repo_issues(db, gh, repo_dict, last_updated_at):
                 entry['closed_at'] = datetime_to_epoch(issue.closed_at)
                 if issue.closed_by:
                     entry['closer'] = issue.closed_by.login
-        db.update('github_issues', entry, ['repo_id', 'number'])
+        repos_db.update('github_issues', entry, ['repo_id', 'number'])
 
-    db.update('github_issues_updates', {'id': repo_id, 'last_updated_at': now})
+    repos_db.update('github_issues_updates', {'id': repo_id, 'last_updated_at': now})
     if progress:
         progress.close()
 
 
-def get_github_issues(db):
-    repos = get_github_repos(db)
+def get_github_issues(repos_db, github_repos):
     to_crawl = []
     now = now_epoch()
 
-    for repo_id, repo_dict in sorted(repos.items(), key=lambda d: (d[1]['org'], d[1]['repo'])):
-        last_updated_at = db.lookup('last_updated_at', 'github_issues_updates', f'WHERE id={repo_id}')
+    for repo_id, repo_dict in sorted(github_repos.items(), key=lambda d: (d[1]['org'], d[1]['repo'])):
+        last_updated_at = repos_db.lookup('last_updated_at', 'github_issues_updates', f'WHERE id={repo_id}')
 
         if last_updated_at:
             if now - last_updated_at < 300000:
@@ -307,7 +217,7 @@ def get_github_issues(db):
     print(gh.get_rate_limit())
     for repo_dict, last_updated_at in tqdm(to_crawl, desc='Repos: GithubIssues'):
         try:
-            get_github_repo_issues(db, gh, repo_dict, last_updated_at)
+            get_github_repo_issues(repos_db, gh, repo_dict, last_updated_at)
         except github.RateLimitExceededException:
             print('Github limit')
             print(gh.get_rate_limit())
@@ -315,26 +225,30 @@ def get_github_issues(db):
 
 
 def update_repos(local_repos=False, github_repos=True):
-    db = MetricDB('repos')
+    rosdistro_db = MetricDB('rosdistro')
+    repos_db = MetricDB('repos')
     try:
-        get_repo_list(db)
+        check_urls(rosdistro_db)
+        rosdistro_ids = get_rosdistro_repos(rosdistro_db)
         if local_repos:
-            repos = clone(db)
-            update(repos)
-            check_statuses(db)
+            repos = clone(rosdistro_db, repos_db, rosdistro_ids)
+            update(repos_db, repos)
+            check_statuses(rosdistro_db, rosdistro_ids)
         if github_repos:
             try:
-                get_github_stats(db)
-                get_github_issues(db)
+                github_repos = get_github_repos(rosdistro_db, rosdistro_ids)
+                get_github_stats(repos_db, github_repos)
+                get_github_issues(repos_db, github_repos)
             except RuntimeError as e:
                 print(e)
     except KeyboardInterrupt:
         pass
     finally:
-        db.close()
+        repos_db.close()
+        rosdistro_db.close()
 
 
-def github_stat_report(db):
+def github_stat_report(db, github_repos):
     report = {}
     ranks = collections.defaultdict(collections.Counter)
 
@@ -390,17 +304,14 @@ def get_issue_report(db):
 def github_repos_report(db=None):
     if db is None:
         db = MetricDB('repos')
-    report = github_stat_report(db)
+    rosdistro_db = MetricDB('rosdistro')
+    github_repos = get_github_repos(rosdistro_db)
+
+    report = github_stat_report(db, github_repos)
     issue_report = get_issue_report(db)
     lines = []
-    for repo_dict in sorted(db.query('SELECT * FROM repos WHERE server="github.com" and status is null'),
-                            key=lambda d: report.get(d['id'], {}).get('rank_product', 0)):
-        id = repo_dict['id']
-        if id not in report:
-            continue
-        for key in ['forks', 'stars', 'subs']:
-            repo_dict[key] = '{:04d} ({})'.format(report[id][key], report[id][key[:-1] + '_rank'])
-        repo_dict['rank_product'] = report[id]['rank_product']
+    for id, repo_dict in github_repos.items():
+        repo_dict.update(report[id])
         for key in issue_report:
             repo_dict[key] = issue_report[key].get(id, '')
 

--- a/ros_metrics/rosdistro.py
+++ b/ros_metrics/rosdistro.py
@@ -1,6 +1,4 @@
 import collections
-import io
-import git
 import pathlib
 import re
 from tqdm import tqdm
@@ -9,6 +7,7 @@ import yaml
 from .constants import distros, ros1_distros
 from .metric_db import MetricDB
 from .people import get_canonical_email
+from .repo_utils import clone_or_update, blob_contents
 from .reports import get_datetime_from_dict, ONE_WEEK
 from .util import version_compare
 
@@ -24,22 +23,7 @@ LEGACY_X2 = re.compile(r'releases/([^\-]*)\-(.*).yaml')
 
 
 def get_rosdistro_repo(update=True):
-    if not REPO_PATH.exists():
-        repo = git.Repo.clone_from(GIT_URL, REPO_PATH)
-    else:
-        repo = git.Repo(REPO_PATH)
-        if update:
-            repo.remotes.origin.pull()
-    return repo
-
-
-def blob_contents(blob):
-    if blob is None:
-        return ''
-    s = ''
-    with io.BytesIO(blob.data_stream.read()) as f:
-        s += f.read().decode('utf-8')
-    return s
+    return clone_or_update(GIT_URL, REPO_PATH, update)[0]
 
 
 def yaml_diff_iterator(a, b, keys=None):

--- a/ros_metrics/rosdistro.py
+++ b/ros_metrics/rosdistro.py
@@ -7,10 +7,9 @@ import yaml
 from .constants import distros, ros1_distros
 from .metric_db import MetricDB
 from .people import get_canonical_email
-from .repo_utils import clone_or_update, blob_contents
+from .repo_utils import clone_or_update, match_git_host, blob_contents
 from .reports import get_datetime_from_dict, ONE_WEEK
 from .util import version_compare
-
 
 GIT_URL = 'https://github.com/ros/rosdistro.git'
 REPO_PATH = pathlib.Path('cache/rosdistro')
@@ -381,7 +380,79 @@ def count_repos(db, commit_id, commit):
         print(e)
 
 
-def update_rosdistro():
+def get_repo_id(db, repo_dict):
+    pieces = [f'{key}="{value}"' for (key, value) in repo_dict.items()]
+    if not pieces:
+        return
+    clause = 'WHERE ' + ' and '.join(pieces)
+    return db.lookup('id', 'repos', clause)
+
+
+def get_repo_id_from_url(db, url):
+    repo_dict = match_git_host(url)
+    if repo_dict:
+        return get_repo_id(db, repo_dict)
+
+
+def resolve_source_url(db, entry, distro, debug=False):
+    # Start by checking source and doc entries
+    url = entry.get('source', entry.get('doc', {})).get('url')
+    if url:
+        return url
+
+    # TODO: Check out release repo
+
+
+def load_repository_info(db, distro, distro_dict):
+    repos = {}
+    if not distro_dict.get('repositories'):
+        return repos
+
+    for entry in distro_dict['repositories'].values():
+        url = resolve_source_url(db, entry, distro)
+        if url is None:
+            # Can't determine source repo
+            continue
+        repo_dict = match_git_host(url)
+        if not repo_dict:
+            # Can't parse url
+            continue
+        id = get_repo_id(db, repo_dict)
+        if id is None:
+            id = db.get_next_id('repos')
+            repo_dict['id'] = id
+            repo_dict['url'] = url
+            db.insert('repos', repo_dict)
+
+        info = {'url': url}
+        version = entry.get('release', {}).get('version')
+        if not version:
+            continue
+        if '-' in version:
+            version, _, _ = version.partition('-')
+        info['version'] = version
+        repos[id] = info
+    return repos
+
+
+def check_tags(db, commit_id, commit):
+    for folder in sorted(commit.tree.trees, key=lambda d: d.name):
+        if folder.name not in distros:
+            continue
+        distro = folder.name
+
+        filename = 'distribution.yaml'
+        try:
+            path = folder[filename]
+        except KeyError:
+            continue
+        distro_dict = yaml.load(blob_contents(path))
+        load_repository_info(db, distro, distro_dict)
+
+    db.insert('tags_checked', {'commit_id': commit_id})
+
+
+def update_rosdistro(should_classify_commits=True, should_count_repos=True, should_check_tags=True):
     # Clone or update the repo in the cache
     repo = get_rosdistro_repo(update=True)
 
@@ -395,14 +466,15 @@ def update_rosdistro():
         main_path = set()
         already_classified = set(db.lookup_all('commit_id', 'changes'))
         already_counted = set(db.lookup_all('commit_id', 'repo_count'))
+        already_tagged = set(db.lookup_all('commit_id', 'tags_checked'))
 
-        for commit_id, commit in enumerate(tqdm(commits)):
+        for commit_id, commit in enumerate(tqdm(commits, desc='rosdistro commits')):
             main_path.add(commit.hexsha)
 
             n += 1
 
             # Check if already classified
-            if commit_id not in already_classified:
+            if commit_id not in already_classified and should_classify_commits:
                 commit_dict, classifications = classify_commit(repo, main_path, commit, commit_id)
                 db.update('commits', commit_dict)
                 if classifications:
@@ -412,16 +484,26 @@ def update_rosdistro():
             else:
                 matched += 1
 
-            if commit_id not in already_counted and commit_id % 100 == 0:
+            if should_count_repos and commit_id not in already_counted and commit_id % 100 == 0:
                 count_repos(db, commit_id, commit)
+
+            if should_check_tags and commit_id not in already_tagged and commit_id % 100 == 0:
+                check_tags(db, commit_id, commit)
 
     except KeyboardInterrupt:
         pass
     finally:
-        n = float(n)
-        print(matched, matched / n)
-        print(new_matches, new_matches / n)
+        if should_classify_commits:
+            n = float(n)
+            print(matched, matched / n)
+            print(new_matches, new_matches / n)
         db.close()
+
+
+def get_rosdistro_repos(db):
+    ids = set(db.lookup_all('id', 'repos'))
+    remaps = db.dict_lookup('id', 'new_id', 'remap_repos')
+    return [remaps.get(id, id) for id in ids]
 
 
 def commit_query(db, fields, clause=''):


### PR DESCRIPTION
The previous version of the utils module crawled the current `rosdistro` repo for repos, but that had some problems. It didn't consider past versions of the rosdistro repo, used the rosdistro entry key as an identifier (which was faulty) and remapping process was weird. 

This PR
 * Moves some common operations into repo_utils
 * Tracks how often the repos are updated
 * Moves the repos table to rosdistro
 * Crawls every commit for repos (as opposed to the most modern)
 * Explicitly tracks renamed/remapped repos. 